### PR TITLE
Cleaned up tests

### DIFF
--- a/tests/SensorUtilsTesting.cpp
+++ b/tests/SensorUtilsTesting.cpp
@@ -6,35 +6,35 @@ TEST(EmissionAngle, TestAngle) {
    vector<double> observerBodyFixedPosition{-2399.5377741187439824,-2374.0338295628557717,1277.6750059817834426};
    vector<double> groundPtIntersection{-2123.3622582859998147,-2380.37178122360001,1194.6783966636000969};
    vector<double> surfaceNormal{-0.62338400000000004919,-0.69883799999999995922,0.35073799999999999422};
-   ASSERT_DOUBLE_EQ(0.81971651917135968102, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+   EXPECT_DOUBLE_EQ(0.81971651917135968102, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
 }
 
 TEST(EmissionAngle, ObserverEquGround) {
    vector<double> observerBodyFixedPosition{0.0,0.0,0.0};
    vector<double> groundPtIntersection{0.0,0.0,0.0};
    vector<double> surfaceNormal{1.0,0.0,0.0};
-   ASSERT_DOUBLE_EQ(M_PI/2.0, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+   EXPECT_DOUBLE_EQ(M_PI/2.0, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
 }
 
 TEST(EmissionAngle, ZeroNormal) {
    vector<double> observerBodyFixedPosition{-2399.5377741187439824,-2374.0338295628557717,1277.6750059817834426};
    vector<double> groundPtIntersection{-2123.3622582859998147,-2380.37178122360001,1194.6783966636000969};
    vector<double> surfaceNormal{0.0, 0.0, 0.0};
-   ASSERT_DOUBLE_EQ(M_PI/2.0, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+   EXPECT_DOUBLE_EQ(M_PI/2.0, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
 }
 
 TEST(EmissionAngle, MinEmission) {
    vector<double> observerBodyFixedPosition{2.0,0.0,0.0};
    vector<double> groundPtIntersection{1.0,0.0,0.0};
    vector<double> surfaceNormal{1.0,0.0,0.0};
-   ASSERT_DOUBLE_EQ(0.0,EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+   EXPECT_DOUBLE_EQ(0.0,EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
 }
 
 TEST(EmissionAngle, MaxEmission) {
    vector<double> observerBodyFixedPosition{1.0,1.0,1.0};
    vector<double> groundPtIntersection{0.0,0.0,0.0};
    vector<double> surfaceNormal{-2.0,-2.0,2.0};
-   ASSERT_DOUBLE_EQ(M_PI,EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+   EXPECT_DOUBLE_EQ(M_PI,EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
 }
 
 

--- a/tests/SensorUtilsTesting.cpp
+++ b/tests/SensorUtilsTesting.cpp
@@ -2,31 +2,39 @@
 #include <cmath>
 #include <gtest/gtest.h>
 
-TEST(SensorUtils, EmissionAngle) {
-   vector<double> observerBodyFixedPosition1{-2399.5377741187439824,-2374.0338295628557717,1277.6750059817834426};
-   vector<double> groundPtIntersection1{-2123.3622582859998147,-2380.37178122360001,1194.6783966636000969};
-   vector<double> surfaceNormal1{-0.62338400000000004919,-0.69883799999999995922,0.35073799999999999422};
-   EXPECT_NEAR(0.81971651917135968102, EmissionAngle(observerBodyFixedPosition1, groundPtIntersection1,surfaceNormal1),1e-5);
+TEST(EmissionAngle, TestAngle) {
+   vector<double> observerBodyFixedPosition{-2399.5377741187439824,-2374.0338295628557717,1277.6750059817834426};
+   vector<double> groundPtIntersection{-2123.3622582859998147,-2380.37178122360001,1194.6783966636000969};
+   vector<double> surfaceNormal{-0.62338400000000004919,-0.69883799999999995922,0.35073799999999999422};
+   ASSERT_DOUBLE_EQ(0.81971651917135968102, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+}
 
-   vector<double> observerBodyFixedPosition2{0.0,0.0,0.0};
-   vector<double> groundPtIntersection2{0.0,0.0,0.0};
-   vector<double> surfaceNormal2{0.0,0.0,0.0};
-   EXPECT_NEAR(M_PI/2.0, EmissionAngle(observerBodyFixedPosition2, groundPtIntersection2,surfaceNormal2),1e-5);
+TEST(EmissionAngle, ObserverEquGround) {
+   vector<double> observerBodyFixedPosition{0.0,0.0,0.0};
+   vector<double> groundPtIntersection{0.0,0.0,0.0};
+   vector<double> surfaceNormal{1.0,0.0,0.0};
+   ASSERT_DOUBLE_EQ(M_PI/2.0, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+}
 
+TEST(EmissionAngle, ZeroNormal) {
+   vector<double> observerBodyFixedPosition{-2399.5377741187439824,-2374.0338295628557717,1277.6750059817834426};
+   vector<double> groundPtIntersection{-2123.3622582859998147,-2380.37178122360001,1194.6783966636000969};
+   vector<double> surfaceNormal{0.0, 0.0, 0.0};
+   ASSERT_DOUBLE_EQ(M_PI/2.0, EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+}
 
-   vector<double> observerBodyFixedPosition3{2.0,0.0,0.0};
-   vector<double> groundPtIntersection3{1.0,0.0,0.0};
-   vector<double> surfaceNormal3{1.0,0.0,0.0};
-   EXPECT_NEAR(0.0,EmissionAngle(observerBodyFixedPosition3, groundPtIntersection3,surfaceNormal3),1e-5);
+TEST(EmissionAngle, MinEmission) {
+   vector<double> observerBodyFixedPosition{2.0,0.0,0.0};
+   vector<double> groundPtIntersection{1.0,0.0,0.0};
+   vector<double> surfaceNormal{1.0,0.0,0.0};
+   ASSERT_DOUBLE_EQ(0.0,EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
+}
 
-
-   vector<double> observerBodyFixedPosition4{1.0,1.0,1.0};
-   vector<double> groundPtIntersection4{0.0,0.0,0.0};
-   vector<double> surfaceNormal4{-2.0,-2.0,2.0};
-   EXPECT_NEAR(M_PI,EmissionAngle(observerBodyFixedPosition4, groundPtIntersection4,surfaceNormal4),1e-5);
-
-
-
+TEST(EmissionAngle, MaxEmission) {
+   vector<double> observerBodyFixedPosition{1.0,1.0,1.0};
+   vector<double> groundPtIntersection{0.0,0.0,0.0};
+   vector<double> surfaceNormal{-2.0,-2.0,2.0};
+   ASSERT_DOUBLE_EQ(M_PI,EmissionAngle(observerBodyFixedPosition, groundPtIntersection,surfaceNormal));
 }
 
 


### PR DESCRIPTION
Split the emission angle test into multiple tests.

Split zero normal and coincident observer and ground point into two tests.

Changed from expect_near to expect_double_eq