### PR TITLE
distance() and resolution()

### DIFF
--- a/include/sensorutils/SensorUtils.h
+++ b/include/sensorutils/SensorUtils.h
@@ -3,10 +3,9 @@
 #include <vector>
 
 using namespace std;
-
-double LineResolution(double focalLength, double lineSumming, double pixelPitch,
-                      const vector<double>& instrumentPosition, 
-                      const vector<double>& surfaceIntersection);
+double Distance(const vector<double>& observerBodyFixedPosition,
+                const vector<double>& surfaceIntersection);
+double Resolution(double distance, double focalLength, double pixelPitch, double summing);
 double PhaseAngle(const vector<double> & instPosition, const vector<double> & sunPosition, const vector<double> & surfaceIntersection);
 double EmissionAngle(const vector<double>  &observerBodyFixedPosition,
                      const vector<double> &groundPtIntersection,

--- a/include/sensorutils/SensorUtils.h
+++ b/include/sensorutils/SensorUtils.h
@@ -4,6 +4,9 @@
 
 using namespace std;
 
+double LineResolution(double focalLength, double lineSumming, double pixelPitch,
+  const vector<double>& instrumentPosition, 
+  const vector<double>& surfaceIntersection);
 double PhaseAngle(vector<double> & instPosition, vector<double> & sunPosition);
 
 #endif

--- a/include/sensorutils/SensorUtils.h
+++ b/include/sensorutils/SensorUtils.h
@@ -3,9 +3,9 @@
 #include <vector>
 
 using namespace std;
-double Distance(const vector<double>& observerBodyFixedPosition,
-                const vector<double>& surfaceIntersection);
-double Resolution(double distance, double focalLength, double pixelPitch, double summing);
+double distance(const vector<double> &observerBodyFixedPosition,
+                const vector<double> &surfaceIntersection);
+double resolution(double distance, double focalLength, double pixelPitch, double summing);
 double PhaseAngle(const vector<double> & instPosition, const vector<double> & sunPosition, const vector<double> & surfaceIntersection);
 double EmissionAngle(const vector<double>  &observerBodyFixedPosition,
                      const vector<double> &groundPtIntersection,

--- a/src/SensorUtils.cpp
+++ b/src/SensorUtils.cpp
@@ -12,16 +12,47 @@ using namespace std;
 using namespace arma;
 
 
+/**
+ * Computes the Euclidean distance in kilometers between two body-fixed positions.
+ *
+ * This function computes the Euclidean distance between a body-fixed observer vector and
+ * a body-fixed surface intersection (ground point) vector.
+ *
+ * @author Ian Humphrey
+ *
+ * @param observerBodyFixedPosition Body-fixed XYZ coordinate of the observer (km)
+ * @param surfaceIntersection Body-fixed XYZ coordinate of the intersection on the surface from
+ *                            the look direction of the observer (km)
+ *
+ * @return double Returns the Euclidean distance (in kilometers)
+ */
 double distance(const vector<double>& observerBodyFixedPosition,
                 const vector<double>& surfaceIntersection) {
-  arma::vec observerPosition(observerBodyFixedPosition);
-  arma::vec intersection(surfaceIntersection);
-  arma::vec absoluteDifference = abs(observerPosition - intersection);
-  arma::vec squared = pow(absoluteDifference, 2);
-  // Square root of the sum-of-squares gives us Euclidean distance
+  vec observerPosition(observerBodyFixedPosition);
+  vec intersection(surfaceIntersection);
+  vec distanceVector = observerPosition - intersection;
+  // Find the magnitude of the distance vector (Euclidean distance) 
+  vec squared = pow(distanceVector, 2);
   return std::sqrt(sum(squared));
 }
 
+
+/**
+ * Computes the resolution of a sensor based on distance from the point-of-interest, focal
+ * length, pixel pitch (size of pixel), and summing mode (scale factor).
+ *
+ * Resolution is computed as meters per pixel.
+ *
+ * @author Ian Humphrey
+ *
+ * @param distance Distance between the sensor and the point-of-interest (km)
+ * @param focalLength Focal length of the sensor (mm)
+ * @param pixelPitch Size of a pixel on the sensor (mm)
+ * @param summing Summing mode of the sensor
+ *
+ * @return double Returns the resolution of the distance between the sensor and the
+ *                point-of-interest in meters/pixel.
+ */
 double resolution(double distance, double focalLength, double pixelPitch, double summing) {
   if (distance < 0.0 || focalLength < 0.0 || pixelPitch < 0.0 || summing < 0.0) {
     return 0.0;

--- a/src/SensorUtils.cpp
+++ b/src/SensorUtils.cpp
@@ -1,6 +1,7 @@
 #include "SensorUtils.h"
 
 #include <cfloat>
+#include <cmath>
 
 #include <iostream>
 #include <vector>
@@ -31,9 +32,7 @@ double distance(const vector<double>& observerBodyFixedPosition,
   vec observerPosition(observerBodyFixedPosition);
   vec intersection(surfaceIntersection);
   vec distanceVector = observerPosition - intersection;
-  // Find the magnitude of the distance vector (Euclidean distance) 
-  vec squared = pow(distanceVector, 2);
-  return std::sqrt(sum(squared));
+  return as_scalar(norm(distanceVector));
 }
 
 
@@ -41,7 +40,8 @@ double distance(const vector<double>& observerBodyFixedPosition,
  * Computes the resolution of a sensor based on distance from the point-of-interest, focal
  * length, pixel pitch (size of pixel), and summing mode (scale factor).
  *
- * Resolution is computed as meters per pixel.
+ * Resolution is computed as meters per pixel. If any of the input parameters are negative,
+ * this function returns 0.0. If focalLength or pixelPitch is 0.0, this function returns 0.0.
  *
  * @author Ian Humphrey
  *
@@ -51,12 +51,16 @@ double distance(const vector<double>& observerBodyFixedPosition,
  * @param summing Summing mode of the sensor
  *
  * @return double Returns the resolution of the distance between the sensor and the
- *                point-of-interest in meters/pixel.
+ *                point-of-interest in meters/pixel. Returns 0.0 if any parameter is
+ *                negative.
  */
 double resolution(double distance, double focalLength, double pixelPitch, double summing) {
-  if (distance < 0.0 || focalLength < 0.0 || pixelPitch < 0.0 || summing < 0.0) {
+  // Make sure none of inputs are negative, and focalLength and pixelPitch can not be zero,
+  // so we don't divide by zero.
+  if (distance < 0.0 || focalLength <= 0.0 || pixelPitch <= 0.0 || summing < 0.0) {
     return 0.0;
   }
+
   return (distance / (focalLength / pixelPitch)) * summing * 1000.0;
 }
 

--- a/src/SensorUtils.cpp
+++ b/src/SensorUtils.cpp
@@ -4,6 +4,19 @@
 #include <iostream>
 #include <vector>
 
+double LineResolution(double focalLength,
+  double lineSumming,
+  double pixelPitch,
+  const vector<double>& instrumentPosition,
+  const vector<double>& surfaceIntersection) {
+    arma::Col<double> instPos(instrumentPosition);
+    arma::Col<double> intersection(surfaceIntersection);
+    arma::Col<double> diff = instPos - intersection;
+    arma::Col<double> squared = arma::pow(diff, 2);
+    double distance = std::sqrt(arma::sum(squared)) * 1000.0;
+    return (distance / (focalLength / pixelPitch)) * lineSumming;
+}
+
 double PhaseAngle(vector<double>& instrumentPosition,vector<double>& sunPosition) {
     return 0.0;
 }

--- a/src/SensorUtils.cpp
+++ b/src/SensorUtils.cpp
@@ -11,7 +11,8 @@ using namespace std;
 
 using namespace arma;
 
-double Distance(const vector<double>& observerBodyFixedPosition,
+
+double distance(const vector<double>& observerBodyFixedPosition,
                 const vector<double>& surfaceIntersection) {
   arma::vec observerPosition(observerBodyFixedPosition);
   arma::vec intersection(surfaceIntersection);
@@ -21,14 +22,12 @@ double Distance(const vector<double>& observerBodyFixedPosition,
   return std::sqrt(sum(squared));
 }
 
-double Resolution(double distance, double focalLength, double pixelPitch, double summing) {
+double resolution(double distance, double focalLength, double pixelPitch, double summing) {
   if (distance < 0.0 || focalLength < 0.0 || pixelPitch < 0.0 || summing < 0.0) {
     return 0.0;
   }
   return (distance / (focalLength / pixelPitch)) * summing * 1000.0;
 }
-
-using namespace arma;
 
 
  /**

--- a/src/SensorUtils.cpp
+++ b/src/SensorUtils.cpp
@@ -5,19 +5,23 @@
 
 #include <armadillo>
 
-using namespace std;
+using namespace arma;
 
-double LineResolution(double focalLength,
-                      double lineSumming,
-                      double pixelPitch,
-                      const vector<double>& instrumentPosition,
-                      const vector<double>& surfaceIntersection) {
-    arma::vec instPos(instrumentPosition);
-    arma::vec intersection(surfaceIntersection);
-    arma::vec diff = instPos - intersection;
-    arma::vec squared = arma::pow(diff, 2);
-    double distance = std::sqrt(arma::sum(squared)) * 1000.0;
-    return (distance / (focalLength / pixelPitch)) * lineSumming;
+double Distance(const vector<double>& observerBodyFixedPosition,
+                const vector<double>& surfaceIntersection) {
+  arma::vec observerPosition(observerBodyFixedPosition);
+  arma::vec intersection(surfaceIntersection);
+  arma::vec absoluteDifference = abs(observerPosition - intersection);
+  arma::vec squared = pow(absoluteDifference, 2);
+  // Square root of the sum-of-squares gives us Euclidean distance
+  return std::sqrt(sum(squared));
+}
+
+double Resolution(double distance, double focalLength, double pixelPitch, double summing) {
+  if (distance < 0.0 || focalLength < 0.0 || pixelPitch < 0.0 || summing < 0.0) {
+    return 0.0;
+  }
+  return (distance / (focalLength / pixelPitch)) * summing * 1000.0;
 }
 
 

--- a/tests/SensorUtilsTesting.cpp
+++ b/tests/SensorUtilsTesting.cpp
@@ -14,7 +14,7 @@ TEST(distance, negative) {
   // Is this the same as a negative distance?
   vector<double> observer{9, 8, 8};
   vector<double> intersection{10, 10, 10};
-  EXPECT_EQ(0.0, distance(intersection, observer));
+  EXPECT_EQ(3.0, distance(intersection, observer));
 }
 
 TEST(distance, zero) {
@@ -45,7 +45,7 @@ TEST(resolution, negativeDistance) {
   double focalLength = 500; // mm
   double pixelPitch = 0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(0.0, resolution(-1.0 * distance, focalLength, pixelPitch, summing));
+  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, negativeFocalLength) {
@@ -54,7 +54,7 @@ TEST(resolution, negativeFocalLength) {
   double focalLength = -500; // mm
   double pixelPitch = 0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(0.0, resolution(distance, -1.0 * focalLength, pixelPitch, summing));
+  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, negativePixelPitch) {
@@ -63,7 +63,7 @@ TEST(resolution, negativePixelPitch) {
   double focalLength = 500; // mm
   double pixelPitch = -0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(0.0, resolution(distance, focalLength, -1.0 * pixelPitch, summing));
+  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, negativeSumming) {
@@ -72,7 +72,7 @@ TEST(resolution, negativeSumming) {
   double focalLength = 500; // mm
   double pixelPitch = 0.1; // mm
   double summing = -1.0; // no summing (no binning)
-  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, -1.0 * summing));
+  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, zeroDivisors) {

--- a/tests/SensorUtilsTesting.cpp
+++ b/tests/SensorUtilsTesting.cpp
@@ -5,25 +5,18 @@
 /**
  * Test distance() function.
  */
-TEST(distance, positive) {
+TEST(distance, simpleDistance) {
   // Easy hand-calculation: sqrt(1^2 + 2^2 + 2^2) ==> sqrt(9) ==> 3
-  vector<double> observer{10, 10, 10};
-  vector<double> intersection{9, 8, 8};
-  EXPECT_EQ(3.0, distance(observer, intersection));
-}
-
-TEST(distance, negative) {
-  // Observer is "inside" the target body (|intersection| > |observer|)
-  // Is this the same as a negative distance?
-  vector<double> observer{9, 8, 8};
-  vector<double> intersection{10, 10, 10};
-  EXPECT_EQ(3.0, distance(intersection, observer));
+  vector<double> fartherPoint{10, 10, 10};
+  vector<double> closerPoint{9, 8, 8};
+  EXPECT_DOUBLE_EQ(3.0, distance(fartherPoint, closerPoint));
+  EXPECT_DOUBLE_EQ(3.0, distance(closerPoint, fartherPoint));
 }
 
 TEST(distance, zero) {
-  // Zero distance (observer on the target exactly)
+  // Zero distance
   vector<double> zero{0.0, 0.0, 0.0};
-  EXPECT_EQ(0.0, distance(zero, zero));   
+  EXPECT_DOUBLE_EQ(0.0, distance(zero, zero));   
 }
 
 /**
@@ -34,7 +27,7 @@ TEST(resolution, allPositive) {
   double focalLength = 500; // mm
   double pixelPitch = 0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(2.0, resolution(distance, focalLength, pixelPitch, summing)); 
+  EXPECT_DOUBLE_EQ(2.0, resolution(distance, focalLength, pixelPitch, summing)); 
 }
 
 TEST(resolution, summingGreaterThanOne) {
@@ -42,7 +35,7 @@ TEST(resolution, summingGreaterThanOne) {
   double focalLength = 500; // mm
   double pixelPitch = 0.1; // mm
   double summing = 2.0; // summing of 2 pixels together (losing resolution)
-  EXPECT_EQ(4.0, resolution(distance, focalLength, pixelPitch, summing));
+  EXPECT_DOUBLE_EQ(4.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, negativeDistance) {
@@ -51,7 +44,7 @@ TEST(resolution, negativeDistance) {
   double focalLength = 500; // mm
   double pixelPitch = 0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
+  EXPECT_DOUBLE_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, negativeFocalLength) {
@@ -60,7 +53,7 @@ TEST(resolution, negativeFocalLength) {
   double focalLength = -500; // mm
   double pixelPitch = 0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
+  EXPECT_DOUBLE_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, negativePixelPitch) {
@@ -69,7 +62,7 @@ TEST(resolution, negativePixelPitch) {
   double focalLength = 500; // mm
   double pixelPitch = -0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
+  EXPECT_DOUBLE_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, negativeSumming) {
@@ -78,7 +71,7 @@ TEST(resolution, negativeSumming) {
   double focalLength = 500; // mm
   double pixelPitch = 0.1; // mm
   double summing = -1.0; // no summing (no binning)
-  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
+  EXPECT_DOUBLE_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
 }
 
 TEST(resolution, zeroDivisors) {
@@ -87,9 +80,9 @@ TEST(resolution, zeroDivisors) {
   double pixelPitch = 0.0; // mm
   double summing = 1.0; // no summing (no binning)
   // Zero pixel pitch
-  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
-  // Zero (focalLength / pixelPitch)
-  EXPECT_EQ(INFINITY, resolution(distance, 0.0, 1.0, summing));
+  EXPECT_DOUBLE_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
+  // Zero focal length
+  EXPECT_DOUBLE_EQ(0.0, resolution(distance, 0.0, 1.0, summing));
 }
 
 TEST(EmissionAngle,zerosForAllInputs) {

--- a/tests/SensorUtilsTesting.cpp
+++ b/tests/SensorUtilsTesting.cpp
@@ -2,52 +2,89 @@
 #include <cmath>
 #include <gtest/gtest.h>
 
-TEST(SensorUtils, distance) {
+TEST(distance, positive) {
   // Easy hand-calculation: sqrt(1^2 + 2^2 + 2^2) ==> sqrt(9) ==> 3
   vector<double> observer{10, 10, 10};
   vector<double> intersection{9, 8, 8};
   EXPECT_EQ(3.0, distance(observer, intersection));
-
-  // Observer is "inside" the target body (|intersection| > |observer|)
-  // Is this the same as a negative distance?
-  EXPECT_EQ(0.0, distance(intersection, observer));
-
-  // Zero distance (observer on the target exactly)
-  vector<double> zero{0.0, 0.0, 0.0};
-  EXPECT_EQ(0.0, distance(zero, zero));
 }
 
-TEST(SensorUtils, resolution) {
+TEST(distance, negative) {
+  // Observer is "inside" the target body (|intersection| > |observer|)
+  // Is this the same as a negative distance?
+  vector<double> observer{9, 8, 8};
+  vector<double> intersection{10, 10, 10};
+  EXPECT_EQ(0.0, distance(intersection, observer));
+}
+
+TEST(distance, zero) {
+  // Zero distance (observer on the target exactly)
+  vector<double> zero{0.0, 0.0, 0.0};
+  EXPECT_EQ(0.0, distance(zero, zero));   
+}
+
+TEST(resolution, allPositive) {
   double distance = 10.0; // km
   double focalLength = 500; // mm
   double pixelPitch = 0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(2.0, resolution(distance, focalLength, pixelPitch, summing));
+  EXPECT_EQ(2.0, resolution(distance, focalLength, pixelPitch, summing)); 
+}
 
+TEST(resolution, summingGreaterThanOne) {
+  double distance = 10.0; // km
+  double focalLength = 500; // mm
+  double pixelPitch = 0.1; // mm
+  double summing = 2.0; // summing of 2 pixels together (losing resolution)
+  EXPECT_EQ(4.0, resolution(distance, focalLength, pixelPitch, summing));
+}
+
+TEST(resolution, negativeDistance) {
   // Negative distance
+  double distance = -10.0; // km
+  double focalLength = 500; // mm
+  double pixelPitch = 0.1; // mm
+  double summing = 1.0; // no summing (no binning)
   EXPECT_EQ(0.0, resolution(-1.0 * distance, focalLength, pixelPitch, summing));
+}
 
+TEST(resolution, negativeFocalLength) {
   // Negative focal length
+  double distance = 10.0; // km
+  double focalLength = -500; // mm
+  double pixelPitch = 0.1; // mm
+  double summing = 1.0; // no summing (no binning)
   EXPECT_EQ(0.0, resolution(distance, -1.0 * focalLength, pixelPitch, summing));
-  
+}
+
+TEST(resolution, negativePixelPitch) {
   // Negative pixel pitch
+  double distance = 10.0; // km
+  double focalLength = 500; // mm
+  double pixelPitch = -0.1; // mm
+  double summing = 1.0; // no summing (no binning)
   EXPECT_EQ(0.0, resolution(distance, focalLength, -1.0 * pixelPitch, summing));
+}
 
+TEST(resolution, negativeSumming) {
   // Negative summing
+  double distance = 10.0; // km
+  double focalLength = 500; // mm
+  double pixelPitch = 0.1; // mm
+  double summing = -1.0; // no summing (no binning)
   EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, -1.0 * summing));
+}
 
+TEST(resolution, zeroDivisors) {
+  double distance = 10.0; // km
+  double focalLength = 500; // mm
+  double pixelPitch = 0.0; // mm
+  double summing = 1.0; // no summing (no binning)
   // Zero pixel pitch
-  EXPECT_EQ(0.0, resolution(distance, focalLength, 0.0, summing));
-
+  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, summing));
   // Zero (focalLength / pixelPitch)
   EXPECT_EQ(INFINITY, resolution(distance, 0.0, 1.0, summing));
 }
-
-TEST(SensorUtils, EmissionAngle) {
-   vector<double> observerBodyFixedPosition1{-2399.5377741187439824,-2374.0338295628557717,1277.6750059817834426};
-   vector<double> groundPtIntersection1{-2123.3622582859998147,-2380.37178122360001,1194.6783966636000969};
-   vector<double> surfaceNormal1{-0.62338400000000004919,-0.69883799999999995922,0.35073799999999999422};
-   EXPECT_NEAR(0.81971651917135968102, EmissionAngle(observerBodyFixedPosition1, groundPtIntersection1,surfaceNormal1),1e-5);
 
 TEST(EmissionAngle,zerosForAllInputs) {
 

--- a/tests/SensorUtilsTesting.cpp
+++ b/tests/SensorUtilsTesting.cpp
@@ -2,45 +2,45 @@
 #include <cmath>
 #include <gtest/gtest.h>
 
-TEST(SensorUtils, Distance) {
+TEST(SensorUtils, distance) {
   // Easy hand-calculation: sqrt(1^2 + 2^2 + 2^2) ==> sqrt(9) ==> 3
   vector<double> observer{10, 10, 10};
   vector<double> intersection{9, 8, 8};
-  EXPECT_EQ(3.0, Distance(observer, intersection));
+  EXPECT_EQ(3.0, distance(observer, intersection));
 
   // Observer is "inside" the target body (|intersection| > |observer|)
   // Is this the same as a negative distance?
-  EXPECT_EQ(0.0, Distance(intersection, observer));
+  EXPECT_EQ(0.0, distance(intersection, observer));
 
   // Zero distance (observer on the target exactly)
   vector<double> zero{0.0, 0.0, 0.0};
-  EXPECT_EQ(0.0, Distance(zero, zero));
+  EXPECT_EQ(0.0, distance(zero, zero));
 }
 
-TEST(SensorUtils, Resolution) {
+TEST(SensorUtils, resolution) {
   double distance = 10.0; // km
   double focalLength = 500; // mm
   double pixelPitch = 0.1; // mm
   double summing = 1.0; // no summing (no binning)
-  EXPECT_EQ(2.0, Resolution(distance, focalLength, pixelPitch, summing));
+  EXPECT_EQ(2.0, resolution(distance, focalLength, pixelPitch, summing));
 
   // Negative distance
-  EXPECT_EQ(0.0, Resolution(-1.0 * distance, focalLength, pixelPitch, summing));
+  EXPECT_EQ(0.0, resolution(-1.0 * distance, focalLength, pixelPitch, summing));
 
   // Negative focal length
-  EXPECT_EQ(0.0, Resolution(distance, -1.0 * focalLength, pixelPitch, summing));
+  EXPECT_EQ(0.0, resolution(distance, -1.0 * focalLength, pixelPitch, summing));
   
   // Negative pixel pitch
-  EXPECT_EQ(0.0, Resolution(distance, focalLength, -1.0 * pixelPitch, summing));
+  EXPECT_EQ(0.0, resolution(distance, focalLength, -1.0 * pixelPitch, summing));
 
   // Negative summing
-  EXPECT_EQ(0.0, Resolution(distance, focalLength, pixelPitch, -1.0 * summing));
+  EXPECT_EQ(0.0, resolution(distance, focalLength, pixelPitch, -1.0 * summing));
 
   // Zero pixel pitch
-  EXPECT_EQ(0.0, Resolution(distance, focalLength, 0.0, summing));
+  EXPECT_EQ(0.0, resolution(distance, focalLength, 0.0, summing));
 
   // Zero (focalLength / pixelPitch)
-  EXPECT_EQ(INFINITY, Resolution(distance, 0.0, 1.0, summing));
+  EXPECT_EQ(INFINITY, resolution(distance, 0.0, 1.0, summing));
 }
 
 TEST(SensorUtils, EmissionAngle) {

--- a/tests/SensorUtilsTesting.cpp
+++ b/tests/SensorUtilsTesting.cpp
@@ -2,6 +2,47 @@
 #include <cmath>
 #include <gtest/gtest.h>
 
+TEST(SensorUtils, Distance) {
+  // Easy hand-calculation: sqrt(1^2 + 2^2 + 2^2) ==> sqrt(9) ==> 3
+  vector<double> observer{10, 10, 10};
+  vector<double> intersection{9, 8, 8};
+  EXPECT_EQ(3.0, Distance(observer, intersection));
+
+  // Observer is "inside" the target body (|intersection| > |observer|)
+  // Is this the same as a negative distance?
+  EXPECT_EQ(0.0, Distance(intersection, observer));
+
+  // Zero distance (observer on the target exactly)
+  vector<double> zero{0.0, 0.0, 0.0};
+  EXPECT_EQ(0.0, Distance(zero, zero));
+}
+
+TEST(SensorUtils, Resolution) {
+  double distance = 10.0; // km
+  double focalLength = 500; // mm
+  double pixelPitch = 0.1; // mm
+  double summing = 1.0; // no summing (no binning)
+  EXPECT_EQ(2.0, Resolution(distance, focalLength, pixelPitch, summing));
+
+  // Negative distance
+  EXPECT_EQ(0.0, Resolution(-1.0 * distance, focalLength, pixelPitch, summing));
+
+  // Negative focal length
+  EXPECT_EQ(0.0, Resolution(distance, -1.0 * focalLength, pixelPitch, summing));
+  
+  // Negative pixel pitch
+  EXPECT_EQ(0.0, Resolution(distance, focalLength, -1.0 * pixelPitch, summing));
+
+  // Negative summing
+  EXPECT_EQ(0.0, Resolution(distance, focalLength, pixelPitch, -1.0 * summing));
+
+  // Zero pixel pitch
+  EXPECT_EQ(0.0, Resolution(distance, focalLength, 0.0, summing));
+
+  // Zero (focalLength / pixelPitch)
+  EXPECT_EQ(INFINITY, Resolution(distance, 0.0, 1.0, summing));
+}
+
 TEST(SensorUtils, EmissionAngle) {
    vector<double> observerBodyFixedPosition1{-2399.5377741187439824,-2374.0338295628557717,1277.6750059817834426};
    vector<double> groundPtIntersection1{-2123.3622582859998147,-2380.37178122360001,1194.6783966636000969};

--- a/tests/SensorUtilsTesting.cpp
+++ b/tests/SensorUtilsTesting.cpp
@@ -2,6 +2,9 @@
 #include <cmath>
 #include <gtest/gtest.h>
 
+/**
+ * Test distance() function.
+ */
 TEST(distance, positive) {
   // Easy hand-calculation: sqrt(1^2 + 2^2 + 2^2) ==> sqrt(9) ==> 3
   vector<double> observer{10, 10, 10};
@@ -23,6 +26,9 @@ TEST(distance, zero) {
   EXPECT_EQ(0.0, distance(zero, zero));   
 }
 
+/**
+ * Test resolution() function
+ */
 TEST(resolution, allPositive) {
   double distance = 10.0; // km
   double focalLength = 500; // mm

--- a/tests/TestyMcTestFace.cpp
+++ b/tests/TestyMcTestFace.cpp
@@ -2,17 +2,6 @@
 
 #include <gtest/gtest.h>
 
-TEST(SensorUtils, LineResolution) {
-  double focalLength = 500; // mm
-  double lineSumming = 1.0; // no binning
-  double pixelPitch = 0.1; // mm
-  vector<double> instrumentPosition{110.0, 0.0, 0.0}; // km
-  vector<double> surfaceIntersection{100.0, 0.0, 0.0}; // km
-  double resolution = LineResolution(focalLength, lineSumming, pixelPitch, instrumentPosition, surfaceIntersection);
-  std::cout << "resolution: " << resolution << std::endl;
-  EXPECT_EQ(0, resolution);
-}
-
 TEST(SensorUtils, PhaseAngle) {
    vector<double> instrumentPosition{0, 0, 0};
    vector<double> sunPosition{0, 0, 0};

--- a/tests/TestyMcTestFace.cpp
+++ b/tests/TestyMcTestFace.cpp
@@ -2,6 +2,17 @@
 
 #include <gtest/gtest.h>
 
+TEST(SensorUtils, LineResolution) {
+  double focalLength = 500; // mm
+  double lineSumming = 1.0; // no binning
+  double pixelPitch = 0.1; // mm
+  vector<double> instrumentPosition{110.0, 0.0, 0.0}; // km
+  vector<double> surfaceIntersection{100.0, 0.0, 0.0}; // km
+  double resolution = LineResolution(focalLength, lineSumming, pixelPitch, instrumentPosition, surfaceIntersection);
+  std::cout << "resolution: " << resolution << std::endl;
+  EXPECT_EQ(0, resolution);
+}
+
 TEST(SensorUtils, PhaseAngle) {
    vector<double> instrumentPosition{0, 0, 0};
    vector<double> sunPosition{0, 0, 0};


### PR DESCRIPTION
This should fix the LineResolution() and SampleResolution() tickets.

Note that this should be addressed when reviewing the API interactions for all of our CSM & SET components.

The ```resolution()``` function provides accurate resolution *unless* the pixels are not square (i.e. line pixel pitch != sample pixel pitch). With how the parameters are being used right now in SensorUtils, ```lineResolution()``` and a ```sampleResolution()``` functions would be identically implemented (with identical parameters). 

To get pixel resolution, ```pixelResolution()``` could be implemented to take the average of the ```lineResolution()``` and the ```sampleResolution()```. This would most-likely be done in a higher-level library. example of one way this could work:

```c++
//SET asks HIGHLEVELAPI for a sensor and gives it an ISD.
  //HIGHLEVELAPI loads available CSM plugins
  //HIGHLEVELAPI acquires the CSM MODEL that can be instantiated from ISD
  //HIGHLEVELAPI returns back success / fail (or an object / pointer to be checked by SET)
//SET uses return to call HIGHLEVELAPI::PixelResolution()
  //HIGHLEVELAPI asks SHAPELIB if the model intersects the shape
  //HIGHLEVELAPI asks MODEL for observer position (or uses ISD)
  //HIGHLEVELAPI asks MODEL for groundPoint (at center???)
  //HIGHLEVELAPI asks SensorUtils to find distance between observerPosition and groundPoint
  //HIGHLEVELAPI asks MODEL for focal length (or uses ISD)
  //HIGHLEVELAPI asks MODEL for **line** and **sample** pixel pitches (or uses ISD)
  //HIGHLEVELAPI asks MODEL for **line** and **sample** summing modes (or uses ISD)
  //HIGHLEVELAPI calls its own pixelResolution():
  {
    double lineResolution = SensorUtils::resolution(distance, focalLength, linePixelPitch, lineSumming);
    double sampResolution = SensorUtilis::resolution(distance, focalLenght, samplePixelPitch, sampleSumming);
    return (lineResolution + sampleResolution) / 2.0;
  }
  //HIGHLEVELAPI  returns pixelResolution to SET
```

    
