### PR TITLE
Removes python from travis conda deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,5 +50,5 @@ after_success:
     fi
   - conda install -y -q conda-build anaconda-client
   - conda config --set anaconda_upload yes
-  - conda build --token $CONDA_UPLOAD_TOKEN --python $PYTHON_VERSION recipes -q
+  - conda build --token $CONDA_UPLOAD_TOKEN recipes -q
 


### PR DESCRIPTION
@makaylas I think that the issue here might be that the python flag was being used, but no python version was being set.  Therefore, the python flag was coming in a the recipe directory (and no required recipe directory was her provided).

