### PR TITLE
Add dot(), normalize(), subtract() to sensormath

### DIFF
--- a/include/sensormath/SensorMath.h
+++ b/include/sensormath/SensorMath.h
@@ -15,11 +15,13 @@ namespace sensormath {
   vec imageToVec(ImagePoint point);
 
   CartesianVector vecToCartesian(vec vec); 
-  ImagePoint vecToImage(vec vec);   
-
-  double distance(CartesianPoint& point1, CartesianPoint& point2); 
+  ImagePoint vecToImage(vec vec);
 
   double angle(CartesianVector ray1, CartesianVector ray2); 
+  double dot(CartesianVector vector1, CartesianVector vector2);
+  double distance(CartesianPoint& point1, CartesianPoint& point2); 
+  CartesianVector normalize(CartesianVector vector);
+  CartesianVector subtract(CartesianVector vector1, CartesianVector vector2);
 
   // TODO: convert rect2lat and lat2rect to use CartesianPoints and CartesianVectors
   vector<double> rect2lat(const vector<double> rectangularCoords);

--- a/src/sensormath/SensorMath.cpp
+++ b/src/sensormath/SensorMath.cpp
@@ -32,6 +32,17 @@ namespace sensormath {
   }
 
 
+  // Calculates the angle between two vectors
+  double angle(CartesianVector ray1, CartesianVector ray2) {
+    if (approx_equal(cartesianToVec(ray1), cartesianToVec(ray2),
+        "absdiff", 1e-4)) {
+      return 0.0; 
+    }
+
+    return acos(norm_dot(cartesianToVec(ray1), cartesianToVec(ray2))); 
+  }
+
+
   /**
    * Computes the Euclidean distance between two CartesianPoints in the units they are provided 
    * in.  
@@ -52,14 +63,43 @@ namespace sensormath {
   }
 
 
-  // Calculates the angle between two vectors
-  double angle(CartesianVector ray1, CartesianVector ray2) {
-    if (approx_equal(cartesianToVec(ray1), cartesianToVec(ray2),
-        "absdiff", 1e-4)) {
-      return 0.0; 
-    }
+  /**
+   * Compute the dot product of two vectors.
+   *
+   * @param vector1 The first CartesianVector.
+   * @param vector2 The second CartesianVector.
+   *
+   * @return double Returns the computed dot product.
+   */
+  double dot(CartesianVector vector1, CartesianVector vector2) {
+    return arma::dot(cartesianToVec(vector1), cartesianToVec(vector2));
+  }
 
-    return acos(norm_dot(cartesianToVec(ray1), cartesianToVec(ray2))); 
+
+  /**
+   * Normalizes a vector to a unit vector.
+   *
+   * @param vector The CartesianVector to normalize.
+   *
+   * @return CartesianVector Returns the normalized vector (unit vector).
+   */
+  CartesianVector normalize(CartesianVector vector) {
+    vec normalizedVector = normalise(cartesianToVec(vector));
+    return vecToCartesian(normalizedVector);
+  }
+
+  /**
+   * Subtracts two vectors.
+   *
+   * @param vector1 The CartesianVector to subtract from (minuend).
+   * @param vector2 The CartesianVector being subtracted (subtrahend).
+   *
+   * @return CartesianVector Returns the difference between vector1 and vector2.
+   */
+  CartesianVector subtract(CartesianVector vector1, CartesianVector vector2) {
+    vec minuend = cartesianToVec(vector1);
+    vec subtrahend = cartesianToVec(vector2);
+    return vecToCartesian(minuend - subtrahend);
   }
 
 

--- a/tests/SensorMathTesting.cpp
+++ b/tests/SensorMathTesting.cpp
@@ -52,9 +52,19 @@ TEST(vecToCartesian, vec) {
 }
 
 
-/**
- * Test distance() function.
- */
+TEST(angle, zero) {
+  CartesianVector zero(0.0, 0.0, 0.0);
+  EXPECT_NEAR(0.0, sensormath::angle(zero, zero),1e-4);   
+}
+
+
+TEST(angle, orthogonal) {
+  CartesianVector ray1(1.0, 2.0, 0.0);
+  CartesianVector ray2(2.0, -1.0, 10.0);
+  EXPECT_NEAR(M_PI/2, sensormath::angle(ray1, ray2),1e-4);   
+}
+
+
 TEST(distance, simpleDistance) {
   // Easy hand-calculation: sqrt(1^2 + 2^2 + 2^2) ==> sqrt(9) ==> 3
   CartesianPoint fartherPoint(10, 10, 10);
@@ -71,16 +81,38 @@ TEST(distance, zero) {
 }
 
 
-TEST(angle, zero) {
-  CartesianVector zero(0.0, 0.0, 0.0);
-  EXPECT_NEAR(0.0, sensormath::angle(zero, zero),1e-4);   
+TEST(dot, simple) {
+  CartesianVector v1(1.0, 2.0, 3.0);
+  CartesianVector v2(-1.0, 2.0, 3.0);
+  EXPECT_DOUBLE_EQ(12.0, sensormath::dot(v1, v2));
 }
 
 
-TEST(angle, orthogonal) {
-  CartesianVector ray1(1.0, 2.0, 0.0);
-  CartesianVector ray2(2.0, -1.0, 10.0);
-  EXPECT_NEAR(M_PI/2, sensormath::angle(ray1, ray2),1e-4);   
+TEST(normalize, simple) {
+  CartesianVector v(9.0, 9.0, 9.0);
+  CartesianVector unit = sensormath::normalize(v);
+  EXPECT_DOUBLE_EQ(1.0/sqrt(3.0), unit.x);
+  EXPECT_DOUBLE_EQ(1.0/sqrt(3.0), unit.y);
+  EXPECT_DOUBLE_EQ(1.0/sqrt(3.0), unit.z);
+}
+
+
+TEST(normalize, zero) {
+  CartesianVector zero(0.0, 0.0, 0.0);
+  CartesianVector unit = sensormath::normalize(zero);
+  EXPECT_DOUBLE_EQ(0.0, unit.x);
+  EXPECT_DOUBLE_EQ(0.0, unit.y);
+  EXPECT_DOUBLE_EQ(0.0, unit.z);
+}
+
+
+TEST(subtract, simple) {
+  CartesianVector v1(1.0, 2.0, 3.0);
+  CartesianVector v2(3.0, 2.0, 1.0);
+  CartesianVector difference = sensormath::subtract(v1, v2);
+  EXPECT_DOUBLE_EQ(-2.0, difference.x);
+  EXPECT_DOUBLE_EQ(0.0, difference.y);
+  EXPECT_DOUBLE_EQ(2.0, difference.z);
 }
 
 


### PR DESCRIPTION
This facilitates #127 and #129.

The methods (except ```rect2lat``` and ```lat2rect```) have been alphabetized inside of ```SensorMath.cpp``` and ```SensorMath.h```.