### PR TITLE
Update gtest.cmake

### DIFF
--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -18,5 +18,5 @@ if (NOT TARGET gtest)
       set_source_files_properties(${_source} PROPERTIES GENERATED 1)
   endforeach()
 
-  add_library(gtest ${GOOGLETEST_SOURCES})
+  add_library(gtest SHARED ${GOOGLETEST_SOURCES})
 endif()


### PR DESCRIPTION
without  ```SHARED```:

```bash
Linking CXX shared library libsensorutils.so
/usr/bin/ld: libgtest.a(gtest-all.cc.o): relocation R_X86_64_32 against `.rodata' can not be used when making a shared object; recompile with -fPIC
libgtest.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
CMakeFiles/sensorutils.dir/build.make:115: recipe for target 'libsensorutils.so.0.1.1' failed
make[2]: *** [libsensorutils.so.0.1.1] Error 1
```