### PR TITLE
updates libname for conda

### DIFF
--- a/recipes/meta.yaml
+++ b/recipes/meta.yaml
@@ -1,5 +1,5 @@
 package:
-  name: sensorutils
+  name: libsensorutils
   version: "{{ GIT_DESCRIBE_TAG }}.{{ GIT_DESCRIBE_NUMBER }}"
 
 source:


### PR DESCRIPTION
Changes the library name with a `lib` prefix. We have been calling our compiled libraries libXYZ so this brings the sensorutils inline with that.  The bindings will then be called `sensorutils`.