### PR TITLE
Gmock

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "gtest"]
-	path = gtest
-	url = https://github.com/google/googletest

--- a/cmake/gtest.cmake
+++ b/cmake/gtest.cmake
@@ -1,19 +1,58 @@
-if (NOT TARGET gtest)
-  set(GOOGLETEST_ROOT gtest/googletest CACHE STRING "Google Test source root")
+find_package(Threads REQUIRED)
 
-  include_directories(SYSTEM
-      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}
-      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/include
-      )
+include(ExternalProject)
+ExternalProject_Add(
+  googletest
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  UPDATE_COMMAND ""
+  INSTALL_COMMAND ""
+  LOG_DOWNLOAD ON
+  LOG_CONFIGURE ON
+  LOG_BUILD ON)
 
-  set(GOOGLETEST_SOURCES
-      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest-all.cc
-      ${PROJECT_SOURCE_DIR}/${GOOGLETEST_ROOT}/src/gtest_main.cc
-      )
+ExternalProject_Get_Property(googletest source_dir)
+set(GTEST_INCLUDE_DIRS ${source_dir}/googletest/include)
+set(GMOCK_INCLUDE_DIRS ${source_dir}/googlemock/include)
 
-  foreach(_source ${GOOGLETEST_SOURCES})
-      set_source_files_properties(${_source} PROPERTIES GENERATED 1)
-  endforeach()
+# The cloning of the above repo doesn't happen until make, however if the dir doesn't
+# exist, INTERFACE_INCLUDE_DIRECTORIES will throw an error.
+# To make it work, we just create the directory now during config.
+file(MAKE_DIRECTORY ${GTEST_INCLUDE_DIRS})
+file(MAKE_DIRECTORY ${GMOCK_INCLUDE_DIRS})
 
-  add_library(gtest ${GOOGLETEST_SOURCES})
-endif()
+ExternalProject_Get_Property(googletest binary_dir)
+set(GTEST_LIBRARY_PATH ${binary_dir}/googlemock/gtest/${CMAKE_FIND_LIBRARY_PREFIXES}gtest.a)
+set(GTEST_LIBRARY gtest)
+add_library(${GTEST_LIBRARY} UNKNOWN IMPORTED)
+set_target_properties(${GTEST_LIBRARY} PROPERTIES
+    "IMPORTED_LOCATION" "${GTEST_LIBRARY_PATH}"
+    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    "INTERFACE_INCLUDE_DIRECTORIES" "${GTEST_INCLUDE_DIRS}")
+add_dependencies(${GTEST_LIBRARY} googletest)
+
+set(GTEST_MAIN_LIBRARY_PATH ${binary_dir}/googlemock/gtest/${CMAKE_FIND_LIBRARY_PREFIXES}gtest_main.a)
+set(GTEST_MAIN_LIBRARY gtest_main)
+add_library(${GTEST_MAIN_LIBRARY} UNKNOWN IMPORTED)
+set_target_properties(${GTEST_MAIN_LIBRARY} PROPERTIES
+    "IMPORTED_LOCATION" "${GTEST_MAIN_LIBRARY_PATH}"
+    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    "INTERFACE_INCLUDE_DIRECTORIES" "${GTEST_INCLUDE_DIRS}")
+add_dependencies(${GTEST_MAIN_LIBRARY} googletest)
+
+set(GMOCK_LIBRARY_PATH ${binary_dir}/googlemock/${CMAKE_FIND_LIBRARY_PREFIXES}gmock.a)
+set(GMOCK_LIBRARY gmock)
+add_library(${GMOCK_LIBRARY} UNKNOWN IMPORTED)
+set_target_properties(${GMOCK_LIBRARY} PROPERTIES
+    "IMPORTED_LOCATION" "${GMOCK_LIBRARY_PATH}"
+    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    "INTERFACE_INCLUDE_DIRECTORIES" "${GMOCK_INCLUDE_DIRS}")
+add_dependencies(${GMOCK_LIBRARY} googletest)
+
+set(GMOCK_MAIN_LIBRARY_PATH ${binary_dir}/googlemock/${CMAKE_FIND_LIBRARY_PREFIXES}gmock_main.a)
+set(GMOCK_MAIN_LIBRARY gmock_main)
+add_library(${GMOCK_MAIN_LIBRARY} UNKNOWN IMPORTED)
+set_target_properties(${GMOCK_MAIN_LIBRARY} PROPERTIES
+    "IMPORTED_LOCATION" "${GMOCK_MAIN_LIBRARY_PATH}"
+    "IMPORTED_LINK_INTERFACE_LIBRARIES" "${CMAKE_THREAD_LIBS_INIT}"
+    "INTERFACE_INCLUDE_DIRECTORIES" "${GMOCK_INCLUDE_DIRS}")
+add_dependencies(${GMOCK_MAIN_LIBRARY} ${GTEST_LIBRARY})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,9 +5,13 @@ set(COVERAGE OFF CACHE BOOL "Coverage")
 
 # Link runSensorUtilsTests with what we want to test and the GTest and pthread library
 
-add_executable(runSensorUtilsTests SensorCoreTesting.cpp SensorMathTesting.cpp SensorModelTesting.cpp ShapeModelTesting.cpp)
+add_executable(runSensorUtilsTests TestMain.cpp
+                                   SensorCoreTesting.cpp
+                                   SensorMathTesting.cpp
+                                   SensorModelTesting.cpp
+                                   ShapeModelTesting.cpp)
 
-target_link_libraries(runSensorUtilsTests PUBLIC sensorutils ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES} pthread)
+target_link_libraries(runSensorUtilsTests PUBLIC sensorutils ${GMOCK_LIBRARY} pthread)
 
 
 if(COVERAGE)

--- a/tests/TestMain.cpp
+++ b/tests/TestMain.cpp
@@ -1,0 +1,7 @@
+#include "gmock/gmock.h"
+
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
- Removes the gtest submodule
- Adds a dynamic download of gtest (this occurs once)
- Adds a main that GMock requires
- Sets the main include to be GMock illustrating that cmake has the proper linking going on.